### PR TITLE
updated to use java8 and elasticsearch 5.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-MAINTAINER steven brezina <steveinatorx@gmail.com>
+LABEL authors="Ryan day <soldair@gmail.com>,steven brezina <steveinatorx@gmail.com>"
 
 RUN apk update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,36 @@
-FROM       luislavena/mini-java
-MAINTAINER Ryan day <soldair@gmail.com>
+FROM alpine:latest
+MAINTAINER steven brezina <steveinatorx@gmail.com>
 
-# FIXME: perhaps all containers can benefit from these packages?
-RUN apk-install ca-certificates curl
+RUN apk update
 
-ENV ELASTICSEARCH_VERSION 1.4.4
+RUN apk add ca-certificates curl bash
+
+RUN apk add openjdk8-jre
+
+ENV ELASTICSEARCH_VERSION 5.0.1
 
 RUN \
   mkdir -p /opt && \
   cd /tmp && \
-  curl https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz > elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
+
+  curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz > elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
   tar -xzf elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
   rm -rf elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
   mv elasticsearch-$ELASTICSEARCH_VERSION /opt/elasticsearch
 
-ADD ./elasticsearch.yml /opt/elasticsearch/config/elasticsearch.yml
+#RUN ls -lart /opt/elasticsearch/bin/elasticsearch
+
+ADD ./elasticsearch.yml /var/lib/elasticsearch/config/elasticsearch.yml
 ADD ./start.sh /start.sh
 
+#es waint let us run as root by default
+RUN adduser -D -u 1001 esrunner
+RUN chown -R esrunner /var/lib/elasticsearch
+RUN chown -R esrunner /opt/elasticsearch
+
+#mount this volume locally if you want to persist your data
 VOLUME ["/var/lib/elasticsearch"]
 
 EXPOSE 9200
 EXPOSE 9300
-
 CMD ["/start.sh"]

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 based on [mini-elasticsearch](https://github.com/luislavena/dockerfiles/tree/master/mini-elasticsearch) by luislavena
 
-A very lightweight [Elasticsearch](http://www.elasticsearch.org/) service container.
+A ~~very~~ somewhat lightweight [Elasticsearch](http://www.elasticsearch.org/) service container.
 
-Updated for coreos
-
+Updated for alpine latest, openjdk8-jre, and elasticsearch 5.0.1
 ## Usage
 
 To run this container and bind port `9200`:

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # uses es home to load all configs.
 # adding a "commandopts" to the volume allows you to pass more options to elasticsearch 
@@ -47,8 +47,8 @@ vol=/var/lib/elasticsearch
 ls $vol
 
 esopts=""
-if [ -f "$vol/elasticsearch.yml" ]; then
-  esopts="-Des.path.home=$vol";
+if [ -f "$vol/config/elasticsearch.yml" ]; then
+  esopts="-Ees.path.home=$vol";
   echo "setting es.path.home to $vol"
 else 
   echo "[WARNING] missing elasticsearch config. not setting es.path.home to $vol"
@@ -71,7 +71,7 @@ echo "-------------------------------"
 echo "/opt/elasticsearch/bin/elasticsearch $commandopts $esopts"
 
 start() {
-	exec /opt/elasticsearch/bin/elasticsearch $commandopts $esopts
+ su esrunner -c '/opt/elasticsearch/bin/elasticsearch $commandopts $esopts'
 }
 
 start


### PR DESCRIPTION
couldnt get this to build and come up locally so i updated to java8 and es5.0.1, added a non-root service runner and switched out to bash (bash may have been unnecessary). 

it runs now you are welcome to pull this and update your docker hub images if you see fit. In any case thanks for the template ! 